### PR TITLE
Add support for setting 'namespace' environment variable

### DIFF
--- a/sentry-kubernetes.go
+++ b/sentry-kubernetes.go
@@ -24,11 +24,17 @@ func main() {
 		panic(err.Error())
 	}
 
-	dsn := os.Getenv("DSN")
+	dsn := os.Getenv("DSN")	
 
 	if dsn == "" {
 		fmt.Println("Missing DSN ENV token")
 		os.Exit(1)
+	}
+
+	namespace := os.Getenv("namespace")	
+
+	if namespace == "" {
+		namespace = api.NamespaceAll
 	}
 
 	client, err := raven.New(dsn)
@@ -49,7 +55,7 @@ func main() {
 	watchlist := cache.NewListWatchFromClient(
 		clientset.Core().RESTClient(),
 		"pods",
-		api.NamespaceAll,
+		namespace,
 		fields.Everything(),
 	)
 


### PR DESCRIPTION
We run several environments on the same cluster and use namespaces to keep them apart. I've added the option to specify namespace as an enviroment variable. 

That way I can have one instance of go-sentry-kubernetes for each namespace. As it was before any issue would be reported as "production" error regardless of namespace.